### PR TITLE
Fix Azure Communication Services get-phone-number link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ __Please note__: Many countries and states have laws and regulations that apply 
 
   * [Step 1: Create a new bot](CreateBot.md). You can skip this step if you already have a working bot. Enable web sockets on the App Service and in your bot code.
 
-  * [Step 2: Get an Azure Communication Services Resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource) and [acquire a phone number in it](https://docs.microsoft.com/azure/communication-services/quickstarts/telephony-sms/get-phone-number).
+  * [Step 2: Get an Azure Communication Services Resource](https://docs.microsoft.com/azure/communication-services/quickstarts/create-communication-resource) and [acquire a phone number in it](https://docs.microsoft.com/azure/communication-services/quickstarts/telephony/get-phone-number).
 
   * [Step 3: Create a Cognitive Services Resource](CreateCogSvcsResource.md). You need an instance of the Speech Service to convert speech to text (for messages _received_ by the bot) and text to speech (for messages _sent_ by the bot). Please note that Telephony channel is currently supported in WestUS2 and EastUS.
 


### PR DESCRIPTION
Current link is a 404 now, updated README to point to the correct page in the documentation.