### PR TITLE
[Post Processing Serial Number] Introducing Custom Substitution

### DIFF
--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SerialNumber.md
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SerialNumber.md
@@ -97,6 +97,37 @@ Sample usage:
     
     // invalid input, result.Length is 0
 
+## Custom Substitution
+We now offer the ability for developers to define their own substitutions as a JSON file and SerialNumberPattern will try to replace all matching input occurrences with the desired character(s).
+This is right now only available when developers have a skill that focuses on post-processing, and is using SerialNumberPattern and SerialNumberTextGroup.
+To make this work, be sure to include all the substitutions for a particular language in a file name like this "substitution-<language code>.json" in the same directory as appsettings.json.
+For example, for substitutions in English, please make a file with the name: substitution.en.json, and have the content as below:
+{
+  "substitutions": [
+    {
+      "substring": "DENIED",
+      "replace_with": "D9"
+    },
+    {
+      "substring": "DENY",
+      "replace_with": "D9"
+    },
+    {
+      "substring": "SEE",
+      "replace_with": "C"
+    },
+    {
+      "substring": "SEA",
+      "replace_with": "C"
+    },
+    {
+      "substring": "SEEN",
+      "replace_with": "CN"
+    }
+  ]
+}
+
+Please ensure that the values for "substring" and "replace_with" for English substitutions are all in capital letters where appropriate.
 
 Currently, post processing for English language is supported.  We are working to add support for Spanish and French.
 

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SerialNumber.md
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SerialNumber.md
@@ -101,7 +101,7 @@ Sample usage:
 We now offer the ability for developers to define their own substitutions as a JSON file and SerialNumberPattern will try to replace all matching input occurrences with the desired character(s).
 This is right now only available when developers have a skill that focuses on post-processing, and is using SerialNumberPattern and SerialNumberTextGroup.
 To make this work, be sure to include all the substitutions for a particular language in a file name like this "substitution-<language code>.json" in the same directory as appsettings.json.
-For example, for substitutions in English, please make a file with the name: substitution.en.json, and have the content as below:
+For example, for substitutions in English, please make a file with the name: substitution-en.json, and have the content as below:
 {
   "substitutions": [
     {

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SpeechSerialNumber.csproj
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/SpeechSerialNumber.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
 </Project>

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/Substitution.cs
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/Substitution.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using Newtonsoft.Json;
+
+namespace SpeechSerialNumber
+{
+    [JsonObject]
+    public class Substitution
+    {
+        [JsonProperty("substring")]
+        public string Substring { get; } = string.Empty;
+
+        [JsonProperty("replace_with")]
+        public string ReplaceWith { get; } = string.Empty;
+
+        public Substitution(string substring, string replaceWith)
+        {
+            this.Substring = substring;
+            this.ReplaceWith = replaceWith;
+        }
+    }
+}

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/Substitution.cs
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumber/Substitution.cs
@@ -10,13 +10,13 @@ namespace SpeechSerialNumber
         [JsonProperty("substring")]
         public string Substring { get; } = string.Empty;
 
-        [JsonProperty("replace_with")]
-        public string ReplaceWith { get; } = string.Empty;
+        [JsonProperty("replacement")]
+        public string Replacement { get; } = string.Empty;
 
-        public Substitution(string substring, string replaceWith)
+        public Substitution(string substring, string replacement)
         {
             this.Substring = substring;
-            this.ReplaceWith = replaceWith;
+            this.Replacement = replacement;
         }
     }
 }

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumberTests/SerialNumberPatternTests.cs
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumberTests/SerialNumberPatternTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using SpeechSerialNumber;
 
 namespace SpeechSerialNumberTests
@@ -10,6 +12,28 @@ namespace SpeechSerialNumberTests
     [TestClass]
     public class SerialNumberPatternTests
     {
+        private static readonly string SubstitutionEnglishFilePath = Path.Combine(".", "substitution-en-us.json");
+
+        [TestInitialize]
+        public void CreateEnglishSubstitutionFile()
+        {
+            Substitution[] substitutions = { new Substitution("DENIED", "D9"), new Substitution("SEE", "C") };
+            Dictionary<string, Substitution[]> substitutionsJsonKVP = new Dictionary<string, Substitution[]>();
+            substitutionsJsonKVP.Add("substitutions", substitutions);
+
+            using (StreamWriter fs = File.CreateText(SubstitutionEnglishFilePath))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                serializer.Serialize(fs, substitutionsJsonKVP);
+            }
+        }
+
+        [TestCleanup]
+        public void DeleteEnglishSubstitutionFile()
+        {
+            this.DeleteSubstitutionFileForEnglish();
+        }
+
         [TestMethod]
         public void MilitaryCodeTest()
         {
@@ -134,6 +158,116 @@ namespace SpeechSerialNumberTests
             result = pattern.Inference("A as in Apple ONE CR 00703 F");
             Assert.IsTrue(result.Length == 1);
             Assert.AreEqual(result[0], "A1CR00703F");
+        }
+
+        [TestMethod]
+        public void HPSerialNumberTestWithoutCustomSubstitutionFile()
+        {
+            this.DeleteSubstitutionFileForEnglish();
+
+            var groups = new List<SerialNumberTextGroup>();
+            var g1 = new SerialNumberTextGroup
+            {
+                AcceptsDigits = true,
+                AcceptsAlphabet = true,
+                LengthInChars = 10,
+            };
+            groups.Add(g1);
+
+            var pattern = new SerialNumberPattern(groups.AsReadOnly());
+            var result = pattern.Inference("A as in Apple 123456789");
+            Assert.IsTrue(result.Length == 2);
+            Assert.AreEqual(result[0], "A1234567A9");
+            Assert.AreEqual(result[1], "A123456789");
+
+            result = pattern.Inference("ONE CR 00703 F 3.");
+            Assert.IsTrue(result.Length == 1);
+            Assert.AreEqual(result[0], "1CR00703F3");
+        }
+
+        [TestMethod]
+        public void EnglishCustomSubstitutionWithDigitWordReplacement()
+        {
+            var groups = new List<SerialNumberTextGroup>();
+            var g1 = new SerialNumberTextGroup
+            {
+                AcceptsDigits = true,
+                AcceptsAlphabet = true,
+                LengthInChars = 10,
+            };
+            groups.Add(g1);
+
+            var pattern = new SerialNumberPattern(groups.AsReadOnly());
+
+            var result = pattern.Inference("ONE DENIED ONE 4 FIVE 6 SEE 1 SEE");
+            Assert.IsTrue(result.Length == 1);
+            Assert.AreEqual(result[0], "1D91456C1C");
+        }
+
+        [TestMethod]
+        public void EnglishCustomSubstitutionWithMilitaryCode()
+        {
+            var groups = new List<SerialNumberTextGroup>();
+            var g1 = new SerialNumberTextGroup
+            {
+                AcceptsDigits = true,
+                AcceptsAlphabet = true,
+                LengthInChars = 10,
+            };
+            groups.Add(g1);
+
+            var pattern = new SerialNumberPattern(groups.AsReadOnly());
+
+            var result = pattern.Inference("ONE DENIED A AS IN APPLE 4 FIVE 6 SEE 1 SEE");
+            Assert.IsTrue(result.Length == 1);
+            Assert.AreEqual(result[0], "1D9A456C1C");
+        }
+
+        [TestMethod]
+        public void EnglishCustomSubstitutionWitAmbiguousInput()
+        {
+            var groups = new List<SerialNumberTextGroup>();
+            var g1 = new SerialNumberTextGroup
+            {
+                AcceptsDigits = true,
+                AcceptsAlphabet = true,
+                LengthInChars = 10,
+            };
+            groups.Add(g1);
+
+            var pattern = new SerialNumberPattern(groups.AsReadOnly());
+
+            var result = pattern.Inference("ONE DENIED A 4 FIVE 8 SEE 1 SEE"); // 8 is ambiguous input
+            Assert.IsTrue(result.Length == 2);
+            Assert.AreEqual(result[0], "1D9A45AC1C");
+            Assert.AreEqual(result[1], "1D9A458C1C");
+        }
+
+        [TestMethod]
+        public void PostProcessedOutputShouldBeTruncatedToPatternLength()
+        {
+            var groups = new List<SerialNumberTextGroup>();
+            var g1 = new SerialNumberTextGroup
+            {
+                AcceptsDigits = true,
+                AcceptsAlphabet = true,
+                LengthInChars = 10,
+            };
+            groups.Add(g1);
+
+            var pattern = new SerialNumberPattern(groups.AsReadOnly());
+
+            var result = pattern.Inference("ONE DENIED A 4 FIVE 6 SEE 1 DENIED"); // 9 at the end should be truncated
+            Assert.IsTrue(result.Length == 1);
+            Assert.AreEqual(result[0], "1D9A456C1D");
+        }
+
+        private void DeleteSubstitutionFileForEnglish()
+        {
+            if (File.Exists(SubstitutionEnglishFilePath))
+            {
+                File.Delete(SubstitutionEnglishFilePath);
+            }
         }
     }
 }

--- a/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumberTests/SerialNumberPatternTests.cs
+++ b/experimental/SerialNumPostProcessingSkillSample/SpeechSerialNumberTests/SerialNumberPatternTests.cs
@@ -12,7 +12,7 @@ namespace SpeechSerialNumberTests
     [TestClass]
     public class SerialNumberPatternTests
     {
-        private static readonly string SubstitutionEnglishFilePath = Path.Combine(".", "substitution-en-us.json");
+        private static readonly string SubstitutionEnglishFilePath = Path.Combine(".", "substitution-en.json");
 
         [TestInitialize]
         public void CreateEnglishSubstitutionFile()


### PR DESCRIPTION
For cases such as D9 where bot interprets as "denied" after speech-to-text, we now have the ability for developers to add their own substitutions in a json file directly in the same directory as appsettings.json in the skill project, and the core post processing logic in SerialNumberPattern will try to replace all occurrence with the desired characters (e.g. replace all occurrence of "denied" with "D9"). For more instruction, please see SerialNumber.md.
